### PR TITLE
Run app in docker container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12
+
+ENV PYTHONUNBUFFERED=1
+ENV POETRY_VIRTUALENVS_CREATE=false
+
+RUN pip install --no-cache-dir poetry uvicorn
+
+WORKDIR /app/backend
+
+COPY pyproject.toml poetry.lock /app/
+
+RUN poetry install --no-dev
+
+COPY . /app/
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "uvicorn app.api.endpoints.main:app --host 0.0.0.0 --port 8000"]


### PR DESCRIPTION
# Test

build docker image:
```
docker build -f backend/Dockerfile -t test-booking-api .                                                                                           ─╯

[+] Building 1.2s (12/12) FINISHED                                                                                                  docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                0.0s
 => => transferring dockerfile: 400B                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/python:3.12                                                                                      1.1s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                     0.0s
 => [1/6] FROM docker.io/library/python:3.12@sha256:2fc3687451585d73c06624d54690baf71c61cc2a144549b5b7dbca60048a5fb2                                0.0s
 => [internal] load build context                                                                                                                   0.0s
 => => transferring context: 23.68kB                                                                                                                0.0s
 => CACHED [2/6] RUN pip install --no-cache-dir poetry uvicorn                                                                                      0.0s
 => CACHED [3/6] WORKDIR /app/backend                                                                                                               0.0s
 => CACHED [4/6] COPY pyproject.toml poetry.lock /app/                                                                                              0.0s
 => CACHED [5/6] RUN poetry install --no-dev                                                                                                        0.0s
 => [6/6] COPY . /app/                                                                                                                              0.0s
 => exporting to image                                                                                                                              0.0s
 => => exporting layers                                                                                                                             0.0s
 => => writing image sha256:c977540fe070941c0ff04031e2572f5c6fc2e2c4e59170d9c40e0710e4c3d88e                                                        0.0s
 => => naming to docker.io/library/test-booking-api                                                                                                 0.0s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/q9bnxh7lcspeusocq6ekyol9o
```

Docker run:
```
docker run --rm -d -p 8000:8000 test-booking-api                                                                                                   ─╯
feb8014bc86ad4530424fc402ccabb33d8e4e9f6dfdf09c75914f659b4d9d165
```

Confirm container is running:
```
docker ps                                                                                                                                          ─╯
CONTAINER ID   IMAGE              COMMAND                  CREATED          STATUS          PORTS                    NAMES
feb8014bc86a   test-booking-api   "sh -c 'uvicorn app.…"   23 seconds ago   Up 22 seconds   0.0.0.0:8000->8000/tcp   ecstatic_germain
```

Accessing the API locally:

<img width="314" alt="Screenshot 2024-12-08 at 12 02 23" src="https://github.com/user-attachments/assets/3feb4c81-5e99-480d-85c6-dc9d129dfc50">

