### PR TITLE
Add black linter

### DIFF
--- a/backend/app/api/endpoints/main.py
+++ b/backend/app/api/endpoints/main.py
@@ -1,4 +1,3 @@
-
 from fastapi import FastAPI
 
 from app.api.endpoints.hotels import router
@@ -19,9 +18,11 @@ app.add_middleware(
 
 app.include_router(router)
 
+
 @app.on_event("startup")
 def startup():
     models.Base.metadata.create_all(bind=database.engine)
+
 
 @app.get("/")
 def read_root():

--- a/backend/app/api/endpoints/services.py
+++ b/backend/app/api/endpoints/services.py
@@ -2,11 +2,13 @@ from typing import Optional
 from playwright.async_api import async_playwright
 from pydantic import BaseModel
 
+
 class Hotel(BaseModel):
     name: str
     address: str
     description: Optional[str]
     review: float
+
 
 def transform_search_name(name: str) -> str:
     """
@@ -44,17 +46,24 @@ async def get_info(page_url: str) -> dict:
         await page.goto(page_url, timeout=60000)
 
         name = await page.query_selector('div[id="hp_hotel_name"] div h2')
-        address = await page.query_selector('#wrap-hotelpage-top > div:nth-child(4) > div > div > span.f419a93f12 > div')
-        description = await page.query_selector('#basiclayout > div.hotelchars > div.page-section.hp--desc_highlights.js-k2-hp--block > div > div.bui-grid__column.bui-grid__column-8.k2-hp--description > div.hp-description > div.hp_desc_main_content > div > div > p.a53cbfa6de.b3efd73f69')
-        review = await page.query_selector('div[data-testid="review-score-right-component"] div')
+        address = await page.query_selector(
+            "#wrap-hotelpage-top > div:nth-child(4) > div > div > span.f419a93f12 > div"
+        )
+        description = await page.query_selector(
+            "#basiclayout > div.hotelchars > div.page-section.hp--desc_highlights.js-k2-hp--block > div > div.bui-grid__column.bui-grid__column-8.k2-hp--description > div.hp-description > div.hp_desc_main_content > div > div > p.a53cbfa6de.b3efd73f69"
+        )
+        review = await page.query_selector(
+            'div[data-testid="review-score-right-component"] div'
+        )
         n = await review.text_content()
 
         return {
             "name": await name.text_content(),
             "address": await address.text_content(),
-            "description": "some_desc", # await description.text_content(),
-            "review": convert_comma_to_dot(n.split()[-1])
+            "description": "some_desc",  # await description.text_content(),
+            "review": convert_comma_to_dot(n.split()[-1]),
         }
+
 
 def convert_comma_to_dot(number_str: str) -> float:
     """

--- a/backend/app/database/crud.py
+++ b/backend/app/database/crud.py
@@ -12,7 +12,9 @@ def get_db():
 
 
 def create_hotel(name: str, address: str, description: str, review: float, db: Session):
-    db_hotel = models.Hotel(name=name, address=address, description=description, review=review)
+    db_hotel = models.Hotel(
+        name=name, address=address, description=description, review=review
+    )
     print(db_hotel)
     print(db)
     db.add(db_hotel)

--- a/backend/app/database/main.py
+++ b/backend/app/database/main.py
@@ -5,10 +5,12 @@ import os
 
 app = FastAPI()
 
+
 @app.on_event("startup")
 def startup():
     print("startup")
     models.Base.metadata.create_all(bind=database.engine)
+
 
 @app.get("/")
 def read_root():

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 
+
 class Hotel(Base):
     __tablename__ = "hotels"
 

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -33,6 +33,50 @@ test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypo
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "black"
+version = "24.10.0"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
+    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
+    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
+    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
+    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
+    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
+    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
+    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
+    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
+    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
+    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
+    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
+    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
+    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
+    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
+    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
+    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
+    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
+    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
+    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
+    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
+    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.10)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -187,6 +231,55 @@ files = [
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
+    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "playwright"
@@ -530,4 +623,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "682323f282d661d787b9770fb0a2b0ad094aa4a3cfc3de2e67fffe55e9ef8fb4"
+content-hash = "629a0f257880c5887c1d2dc279f782274778fc0ec661fbe6bd7c0b6a8a33ddbb"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,6 +12,7 @@ playwright = "^1.49.0"
 uvicorn = "^0.32.1"
 sqlalchemy = "^2.0.36"
 psycopg2 = "^2.9.10"
+black = "^24.10.0"
 
 
 [build-system]


### PR DESCRIPTION
Added black linter to pyproject.toml and updated poetry.lock

`poetry add black`

Fix code to pass black linter

The changes in the second commit were made automatically by the black linter.

```
poetry run black .                                                                                                                                
reformatted ~/athlos/ta-ast-api/backend/app/api/endpoints/main.py
reformatted ~/athlos/ta-ast-api/backend/app/database/main.py
reformatted ~/athlos/ta-ast-api/backend/app/database/crud.py
reformatted ~/athlos/ta-ast-api/backend/app/database/models.py
reformatted ~/athlos/ta-ast-api/backend/app/api/endpoints/services.py
reformatted ~/athlos/ta-ast-api/backend/app/api/endpoints/hotels.py
````