### PR TITLE
FIX: Move check linter to correct directory

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  lint:
+  check:
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     defaults:
-        run:
-            working-directory: ./backend
+      run:
+        working-directory: ./backend
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The GitHub Action was created in the wrong directory inside the backend directory. The correct directory is in the root project directory.


Further information:
https://docs.github.com/en/actions/writing-workflows/quickstart#creating-your-first-workflow

After fixing the GitHub Action configuration, a branch rule protection was created to allow merging the PR to the master branch, only when the check is OK.

Setting >> Branches >> Branch protection rules
 
<img width="757" alt="Screenshot 2024-12-14 at 14 56 56" src="https://github.com/user-attachments/assets/6c5451a8-cc29-44d1-bcb7-221b66a355c7" />

