### PR TITLE
Add isort lint

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -37,3 +37,7 @@ jobs:
       - name: Run Pylint
         run: |
             poetry run pylint **/*.py
+
+      - name: Run isort
+        run: |
+            poetry run isort --check-only .  # Check import sorting without making changes

--- a/backend/app/api/endpoints/hotels.py
+++ b/backend/app/api/endpoints/hotels.py
@@ -3,15 +3,16 @@ Endpoints for scraping and saving hotel data.
 """
 
 from typing import Dict, Union
-from playwright.async_api import async_playwright
-from fastapi import APIRouter, HTTPException
+
 from app.api.endpoints.services import (
+    Hotel,
+    convert_comma_to_dot,
     get_info,
     transform_search_name,
-    convert_comma_to_dot,
-    Hotel,
 )
 from app.database import crud
+from fastapi import APIRouter, HTTPException
+from playwright.async_api import async_playwright
 
 router = APIRouter()
 

--- a/backend/app/api/endpoints/main.py
+++ b/backend/app/api/endpoints/main.py
@@ -2,11 +2,10 @@
 Main FastAPI application setup with CORS middleware and database initialization.
 """
 
+from app.api.endpoints.hotels import router
+from app.database import database, models
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-
-from app.api.endpoints.hotels import router
-from app.database import models, database
 
 app = FastAPI()
 

--- a/backend/app/api/endpoints/services.py
+++ b/backend/app/api/endpoints/services.py
@@ -1,6 +1,7 @@
 """This module provides services for scraping hotel information from web pages using Playwright."""
 
 from typing import Dict, Optional, Union
+
 from playwright.async_api import async_playwright
 from pydantic import BaseModel
 

--- a/backend/app/database/crud.py
+++ b/backend/app/database/crud.py
@@ -1,8 +1,8 @@
 """This module provides CRUD operations for the Hotel model in the database."""
 
-from sqlalchemy.orm import Session
 from app.database import models
 from app.database.database import SessionLocal
+from sqlalchemy.orm import Session
 
 
 def get_db():

--- a/backend/app/database/main.py
+++ b/backend/app/database/main.py
@@ -1,7 +1,7 @@
 """Main module for FastAPI application with PostgreSQL database integration."""
 
+from app.database import database, models
 from fastapi import FastAPI
-from app.database import models, database
 
 app = FastAPI()
 

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -1,6 +1,6 @@
 """This module defines the SQLAlchemy ORM model for the Hotel entity."""
 
-from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy import Column, Float, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -778,4 +778,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "787813a0721ca45fd0731200e01e611da032f14c6ecda137d512a6e8215cee34"
+content-hash = "a938de7cc7851dd9d1ac9bdb6cf1d6e021582b61ebab61ef014717ca684edf78"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ sqlalchemy = "^2.0.36"
 psycopg2 = "^2.9.10"
 black = "^24.10.0"
 pylint = "^3.3.2"
+isort = "^5.13.2"
 
 
 [build-system]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,3 +20,8 @@ isort = "^5.13.2"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.isort]
+profile = "black"
+known_third_party = ["app"]
+line_length = 88


### PR DESCRIPTION
These changes were made automatically to add/fix isort linting issues.

- Add isort support:
`poetry add isort`

- Add isort config to avoid conflict to black

- Fixing code
```
poetry run isort .                                                                                                                                 ─╯
Fixing ~/athlos/ta-ast-api/backend/app/database/models.py
Fixing ~/athlos/ta-ast-api/backend/app/database/main.py
Fixing ~/athlos/ta-ast-api/backend/app/database/crud.py
Fixing ~/athlos/ta-ast-api/backend/app/api/endpoints/services.py
Fixing ~/athlos/ta-ast-api/backend/app/api/endpoints/hotels.py
Fixing ~/athlos/ta-ast-api/backend/app/api/endpoints/main.py
```

- Add isort to GitHub Action
<img width="1124" alt="Screenshot 2024-12-14 at 15 33 29" src="https://github.com/user-attachments/assets/576e8938-6e7c-46db-ac13-637e9a4f3b5a" />

