### PR TITLE
Add `--diff` to black command

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Black
         run: |
-            poetry run black --check .  # Check formatting without making changes
+            poetry run black --check --diff .  # Check formatting without making changes
 
       - name: Run Pylint
         run: |


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to include the `--diff` flag in the black command.

This change ensures that black will show the differences it would make to the code, which helps in identifying formatting issues in the git hub actions logs.

tested locally:

```bash
poetry run black --check --diff .                                                                                                                  ─╯
--- ~/athlos/ta-ast-api/backend/app/api/endpoints/hotels.py     2024-12-14 17:03:06.312608+00:00
+++ ~/athlos/ta-ast-api/backend/app/api/endpoints/hotels.py     2024-12-14 17:03:32.200372+00:00
@@ -2,11 +2,16 @@
 Endpoints for scraping and saving hotel data.
 """

 from typing import Dict, Union

-from app.api.endpoints.services import (Hotel, convert_comma_to_dot, get_info, transform_search_name,)
+from app.api.endpoints.services import (
+    Hotel,
+    convert_comma_to_dot,
+    get_info,
+    transform_search_name,
+)
 from app.database import crud
 from fastapi import APIRouter, HTTPException
 from playwright.async_api import async_playwright

 router = APIRouter()
would reformat /Users/ctw00944-admin/ctw/athlos/ta-ast-api/backend/app/api/endpoints/hotels.py

Oh no! 💥 💔 💥
1 file would be reformatted, 8 files would be left unchanged.
```